### PR TITLE
Add theme compilation on deployment

### DIFF
--- a/iq_barrio_helper.deploy.php
+++ b/iq_barrio_helper.deploy.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @file
+ * Deployment hooks.
+ *
+ * This is a NAME.deploy.php file. It contains "deploy" functions.
+ * These are one-time functions that run *after* config is imported
+ * during a deployment. These are a higher level alternative to
+ * hook_update_n and hook_post_update_NAME functions.
+ *
+ * @link https://www.drush.org/latest/deploycommand/#authoring-update-functions  for a detailed comparison. @endlink
+ */
+
+/**
+ * Themes compilation on deployment.
+ */
+function iq_barrio_helper_deploy_themes() {
+  // Interpolate configuration values in the scss definition file.
+  $service = \Drupal::service('iq_barrio_helper.iq_barrio_service');
+  $service->interpolateConfig();
+
+  // Scss compilation options.
+  $options = [
+      'folders' => 'themes,modules,sites/default/files/styling_profiles',
+      'continueOnErrors' => false
+  ];
+
+  // Compile scss in themes.
+  $sassCommands = \Drupal::service('iq_scss_compiler.sass_commands');
+  $sassCommands->compile($options);
+
+  return 'Deployed themes successfully';
+}
+
+/**
+ * Resets deploy hooks.
+ */
+function iq_barrio_helper_deploy_themes_reset_a() {
+  $hooks = [
+    "iq_barrio_helper_deploy_themes",
+    "iq_barrio_helper_deploy_themes_reset_a",
+    "iq_barrio_helper_deploy_themes_reset_b",
+  ];
+  // Reset deploy hooks.
+  $key_value = \Drupal::keyValue('deploy_hook');
+  $update_list = $key_value->get('existing_updates');
+  if ($update_list) {
+    foreach ($hooks as $hook) {
+      $index = array_search($hook, $update_list);
+      if ($index !== false) {
+        unset($update_list[$index]);
+      }
+    }
+    $key_value->set('existing_updates', $update_list);
+  }
+}
+
+/**
+ * Resets deploy hooks.
+ */
+function iq_barrio_helper_deploy_themes_reset_b() {
+  // Reset deploy hooks.
+  iq_barrio_helper_deploy_themes_reset_a();
+}


### PR DESCRIPTION
## Tasks
- [x] Make themes compile automatically on deployment
- [x] Possible solution: add `HOOK_deploy_NAME()` which is called on `drush deploy` ([Docs](https://www.drush.org/latest/deploycommand/), [Example](https://github.com/drush-ops/drush/blob/11.x/tests/functional/resources/modules/d8/woot/woot.deploy.php))

## Discussion
* Should the deployment fail when the compilation fails?
  * Currently it does, and I also think it should.